### PR TITLE
Assuming type on keys for Redis as bytes

### DIFF
--- a/src/pyramid_kvs2/kvs.py
+++ b/src/pyramid_kvs2/kvs.py
@@ -82,8 +82,8 @@ class Redis(KVS):
         return self._client.incr(self._get_key(key))
 
     def get_keys(self, pattern: str = "*") -> List[str]:
-        keys = self._client.keys(self._get_key(pattern))
-        return [key.replace(self.key_prefix, "") for key in keys]
+        keys: List[bytes] = self._client.keys(self._get_key(pattern))
+        return [key.replace(self.key_prefix, b"").decode("utf-8") for key in keys]
 
 
 class _NoCodec:


### PR DESCRIPTION
Iterating over keys would fail as Redis returns keys as bytes:

```python
from redis import Redis

client = Redis(host="localhost")

client.sadd("key", 1)
print(client.keys())
```

Will print:
```
[b'key']
```